### PR TITLE
[FIX] Cambiada imagen de python3.7

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-from python:3.7-alpine
+from nickgryg/alpine-pandas:3.7
 
 RUN apk add --no-cache git postgresql-dev gcc libc-dev
 RUN apk add --no-cache gcc g++ make libffi-dev python3-dev build-base gettext


### PR DESCRIPTION
Con pandas precompilado, docker debe tardar considerablemente menos tiempo en hacer una build